### PR TITLE
Add namelist support for SE-CSLAM grids & remove a few isotope runoff history fields

### DIFF
--- a/bld/namelist_files/namelist_defaults_clm4_0.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_0.xml
@@ -336,10 +336,14 @@ lnd/clm2/surfdata_map/surfdata_ne4np4_simyr2000_c120126.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne16np4_simyr2000_c120126.nc</fsurdat>
 <fsurdat hgrid="ne30np4" sim_year="2000" irrig=".false.">
 lnd/clm2/surfdata_map/surfdata_ne30np4_simyr2000_c110801.nc</fsurdat>
+<fsurdat hgrid="ne30pg3" sim_year="1850" use_crop=".false." irrigate=".true.">
+lnd/clm2/surfdata_map/surfdata_ne30pg3_hist_16pfts_Irrig_CMIP6_simyr1850_c190228.nc</fsurdat>
 <fsurdat hgrid="ne60np4" sim_year="2000" irrig=".false.">
 lnd/clm2/surfdata_map/surfdata_ne60np4_simyr2000_c120416.nc</fsurdat>
 <fsurdat hgrid="ne120np4" sim_year="2000" irrig=".false.">
 lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2000_c130313.nc</fsurdat>
+<fsurdat hgrid="ne120np4.pg3" sim_year="1850" use_crop=".false." irrigate=".true.">
+lnd/clm2/surfdata_map/surfdata_ne120np4.pg3_hist_16pfts_Irrig_CMIP6_simyr1850_c190814.nc</fsurdat>
 <fsurdat hgrid="ne240np4" sim_year="2000" irrig=".false.">
 lnd/clm2/surfdata_map/surfdata_ne240np4_simyr2000_c130313.nc</fsurdat>
 

--- a/bld/namelist_files/namelist_definition_clm4_0.xml
+++ b/bld/namelist_files/namelist_definition_clm4_0.xml
@@ -678,7 +678,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"  
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.47x0.63,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne16np4,ne30np4,ne60np4,ne120np4,ne240np4">
+"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.47x0.63,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne16np4,ne30np4,ne30pg3,ne60np4,ne120np4,ne120np4.pg3,ne240np4">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry> 
@@ -692,7 +692,7 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 
 <entry id="mask" type="char*10" category="default_settings"
        group="default_settings"  
-       valid_values="USGS,gx3v7,gx1v6,gz1v7,navy,test,tx0.1v2,tx1v1,T62,cruncep">
+       valid_values="USGS,gx3v7,gx1v6,gx1v7,gz1v7,navy,test,tx0.1v2,tx0.1v3,tx1v1,T62,cruncep">
 Land mask description
 </entry> 
 

--- a/src_clm40/main/histFldsMod.F90
+++ b/src_clm40/main/histFldsMod.F90
@@ -849,17 +849,18 @@ call get_proc_bounds(begg, endg, begl, endl, begc, endc, begp, endp)
          avgflag='A', long_name='ice dynamic land cover change conversion runoff flux', &                                   
          ptr_lnd=gwf%qflx_ice_dynbal)
 
-    do m=1,pwtrc
-      ptr1d => gwf%wtr_qflx_liq_dynbal(:,m)
-      call hist_addfld1d (fname='QFLX_LIQ_DYNBAL_'//trim(wtrcnam(m)), units='mm/s',  &    
-           avgflag='A', long_name=trim(wtrcnam(m))//' liq dynamic land cover change conversion runoff flux', &     
-           ptr_lnd=ptr1d)     
+   ! These variables may go out of range of single precision float
+   !do m=1,pwtrc
+   !  ptr1d => gwf%wtr_qflx_liq_dynbal(:,m)
+   !  call hist_addfld1d (fname='QFLX_LIQ_DYNBAL_'//trim(wtrcnam(m)), units='mm/s',  &    
+   !       avgflag='A', long_name=trim(wtrcnam(m))//' liq dynamic land cover change conversion runoff flux', &     
+   !       ptr_lnd=ptr1d)     
 
-      ptr1d => gwf%wtr_qflx_ice_dynbal(:,m)
-      call hist_addfld1d (fname='QFLX_ICE_DYNBAL_'//trim(wtrcnam(m)), units='mm/s',  &
-           avgflag='A', long_name=trim(wtrcnam(m))//' ice dynamic land cover change conversion runoff flux', &                                       
-           ptr_lnd=ptr1d)
-    end do
+   !  ptr1d => gwf%wtr_qflx_ice_dynbal(:,m)
+   !  call hist_addfld1d (fname='QFLX_ICE_DYNBAL_'//trim(wtrcnam(m)), units='mm/s',  &
+   !       avgflag='A', long_name=trim(wtrcnam(m))//' ice dynamic land cover change conversion runoff flux', &                                       
+   !       ptr_lnd=ptr1d)
+   !end do
 
     call hist_addfld1d (fname='QRUNOFF_U', units='mm/s',  &
          avgflag='A', long_name='Urban total runoff', &


### PR DESCRIPTION
The namelist changes are needed if run iCESM in SE-CSLAM grid.
The isotope runoff fields, QFLX_LIQ_DYNBAL_* and QFLX_ICE_DYNBAL_* may go out of range.

Thank you!