### PR TITLE
Fixing time vars in hi-freq history files

### DIFF
--- a/src_clm40/main/histFileMod.F90
+++ b/src_clm40/main/histFileMod.F90
@@ -2909,9 +2909,11 @@ contains
           endif
 
           ! Write time constant history variables
-          if (tape(t)%ntimes == 1) then
-             call htape_timeconst(t, mode='write')
-          endif
+          ! Remove if/then statement to properly print out time variables (at tape(t)%ntimes > 1) 
+          ! in high frequency CLM history files (macarew)
+          !if (tape(t)%ntimes == 1) then
+          call htape_timeconst(t, mode='write')
+          !endif
 
           ! Write 3D time constant history variables only to first primary tape
           if ( do_3Dtconst .and. t == 1 .and. tape(t)%ntimes == 1 )then


### PR DESCRIPTION
- Issue: time variables (e.g. time, nstep, mcdate) in hi frequency history files had incorrect/missing values after first entry
- Enable time variables to be printed out in history files with more than 1 time entry
- Comment out if/then statement around call htape_timeconst(t, mode='write') in src_clm40/main/histFileMod.F90